### PR TITLE
Fix WebUI startup failure when ~/.ssh is empty

### DIFF
--- a/modules/base/docker/o5gc/webui/entrypoint.sh
+++ b/modules/base/docker/o5gc/webui/entrypoint.sh
@@ -7,7 +7,7 @@ envsubst.sh /mnt/webui/nginx.conf /etc/nginx/nginx.conf
 service nginx configtest
 service nginx start
 
-if [ -d /mnt/.ssh/ ]; then
+if [ -d /mnt/.ssh/ ] && [ "$(ls -A /mnt/.ssh/)" ]; then
     cp -a /mnt/.ssh/* ~/.ssh
     chown $(id -u):$(id -g) ~/.ssh/*
     echo -e "Host *\n\tUser ${HOST_USER}" >> ~/.ssh/config


### PR DESCRIPTION
Fixes an issue where the WebUI container fails to start and enters an unhealthy restart loop if the mounted ~/.ssh directory exists but is empty.

The startup script uses 'set -ex', causing the container to exit when attempting to copy non-existent files from '/mnt/.ssh/*'.

This mainly affects local-only or single-host setups where SSH keys are not required.

The fix adds a check to ensure the directory contains files before attempting the copy operation.