### PR TITLE
fix(osmocom-2g): restore MGW client config in osmo-bsc.cfg

### DIFF
--- a/modules/o5gc/docker/osmocom/osmo-bsc.cfg
+++ b/modules/o5gc/docker/osmocom/osmo-bsc.cfg
@@ -23,6 +23,9 @@ network
  handover1 power budget hysteresis 3
  handover1 maximum distance 9999
  periodic location update 30
+ mgw 0
+  remote-ip ${OSMO_MGW_IP_ADDR}
+  remote-port ${OSMO_MGW_MGCP_PORT}
  bts 0
   type osmo-bts
   band ${GSM_BAND}


### PR DESCRIPTION
The MGW client config was removed from the `msc 0` node in `osmo-bsc.cfg` in the commit that updated the osmocom version, so osmo-bsc falls back to its built-in default of 127.0.0.1:2427. Because each component has its own IP, that loopback default never reaches the MGW. I re-added the MGW config as a separate `mgw 0` node under `network`, matching the syntax recommended in the current OsmoBSC User Manual.