### PR TITLE
Overhaul Robot Framework test suites

### DIFF
--- a/modules/o5gc/stacks/oai-5g-basic/tests/rfsim.robot
+++ b/modules/o5gc/stacks/oai-5g-basic/tests/rfsim.robot
@@ -1,60 +1,31 @@
 *** Settings ***
 Documentation   OAI 5G SA basic rfsim
-Force Tags      Emulated
+Test Tags       Emulated  oai-ran  oai-cn
 Resource        ../../../../../tests/common.resource
-
-Suite Setup     Setup Suite
-Suite Teardown  Teardown Suite
+Suite Setup     Setup Stack
+Suite Teardown  Teardown Stack
 
 
 *** Variables ***
-${STACK}  oai-5g-basic-rfsim
+${STACK}          oai-5g-basic-rfsim
+${UE_TYPE}        oai
+${CORE_TYPE}      oai
+@{CONTAINERS}     upf  smf  amf  nrf  udr  udm  ausf  gnb  ue  mysql
+@{FILES_TO_SAVE}  gnb:/o5gc/openairinterface5g/etc/gnb.conf  ue:/o5gc/openairinterface5g/etc/nr-ue.conf
 
 
 *** Test Cases ***
 Verify Successful Startup
-    Containers Should Running  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue  mysql
+    Containers Should Be Running  @{CONTAINERS}
     No Running Container Should Be  unhealthy
     No Running Container Should Be  starting
     No Container Should Be Failed
 
 Verify UE Is Registered At AMF
-    ${MCC}=  Get Env  MCC
-    ${MNC}=  Get Env  MNC
-    ${UE_SOFT_MSIN}=  Get Env  UE_SOFT_MSIN
-    Container Log Should Match Regexp  amf  5GMM-REGISTERED\\s+\\|\\s+${MCC}${MNC}${UE_SOFT_MSIN}
+    UE Should Be Registered At AMF
 
 Verify UE Connectivity
-    OAI UE Should Can Ping  8.8.8.8
+    UE Should Reach The Internet
 
 Verify PDU Session Establishment At SMF
-    OAI SMF Log Should Contain PDU Session Setup
-
-Collect Test Data
-    Collect Container Logs
-    Collect Container Versions
-    Collect Configuration Files
-
-
-*** Keywords ***
-Setup Suite
-    Log To Console  Setup Suite: run 'make run-${STACK}'
-    Start Process   make  run-${STACK}
-    Sleep  5s
-    Process Should Be Running
-    Wait Until Startup Complete  OAI SMF Log Should Contain PDU Session Setup
-
-Teardown Suite
-    Log To Console  Teardown Suite: run 'make stop-${STACK}'
-    Run Process   make  stop-${STACK}
-    No Container Should Running  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue  mysql
-    Terminate All Processes  kill=True
-
-Collect Container Logs
-    Save Container Logs  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue
-
-Collect Container Versions
-    Set Container Versions Metadata  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue
-
-Collect Configuration Files
-    Save Local Files  gnb.conf  ue.conf
+    SMF Log Should Contain PDU Session Setup

--- a/modules/o5gc/stacks/oai-5g-minimalist/tests/rfsim.robot
+++ b/modules/o5gc/stacks/oai-5g-minimalist/tests/rfsim.robot
@@ -1,59 +1,31 @@
 *** Settings ***
 Documentation   OAI 5G SA minimalist rfsim
-Force Tags      Emulated
+Test Tags       Emulated  oai-ran  oai-cn
 Resource        ../../../../../tests/common.resource
+Suite Setup     Setup Stack
+Suite Teardown  Teardown Stack
 
-Suite Setup     Setup Suite
-Suite Teardown  Teardown Suite
 
 *** Variables ***
-${STACK}  oai-5g-minimalist-rfsim
+${STACK}          oai-5g-minimalist-rfsim
+${UE_TYPE}        oai
+${CORE_TYPE}      oai
+@{CONTAINERS}     upf  smf  amf  gnb  ue  mysql
+@{FILES_TO_SAVE}  gnb:/o5gc/openairinterface5g/etc/gnb.conf  ue:/o5gc/openairinterface5g/etc/nr-ue.conf
 
 
 *** Test Cases ***
 Verify Successful Startup
-    Containers Should Running  upf  smf  amf  gnb  ue  mysql
+    Containers Should Be Running  @{CONTAINERS}
     No Running Container Should Be  unhealthy
     No Running Container Should Be  starting
     No Container Should Be Failed
 
 Verify UE Is Registered At AMF
-    ${MCC}=  Get Env  MCC
-    ${MNC}=  Get Env  MNC
-    ${UE_SOFT_MSIN}=  Get Env  UE_SOFT_MSIN
-    Container Log Should Match Regexp  amf  5GMM-REGISTERED\\s+\\|\\s+${MCC}${MNC}${UE_SOFT_MSIN}
+    UE Should Be Registered At AMF
 
 Verify UE Connectivity
-    OAI UE Should Can Ping  8.8.8.8
+    UE Should Reach The Internet
 
 Verify PDU Session Establishment At SMF
-    OAI SMF Log Should Contain PDU Session Setup
-
-Collect Test Data
-    Collect Container Logs
-    Collect Container Versions
-    Collect Configuration Files
-
-
-*** Keywords ***
-Setup Suite
-    Log To Console  Setup Suite: run 'make run-${STACK}'
-    Start Process   make  run-${STACK}
-    Sleep  5s
-    Process Should Be Running
-    Wait Until Startup Complete  OAI SMF Log Should Contain PDU Session Setup
-
-Teardown Suite
-    Log To Console  Teardown Suite: run 'make stop-${STACK}'
-    Run Process   make  stop-${STACK}
-    No Container Should Running  upf  smf  amf  gnb  ue  mysql
-    Terminate All Processes  kill=True
-
-Collect Container Logs
-    Save Container Logs  upf  smf  amf  gnb  ue
-
-Collect Container Versions
-    Set Container Versions Metadata  upf  smf  amf  gnb  ue
-
-Collect Configuration Files
-    Save Local Files  gnb.conf  ue.conf
+    SMF Log Should Contain PDU Session Setup

--- a/modules/o5gc/stacks/srsran-open5gs-5g-emu/tests/zmqsim.robot
+++ b/modules/o5gc/stacks/srsran-open5gs-5g-emu/tests/zmqsim.robot
@@ -1,60 +1,31 @@
 *** Settings ***
 Documentation   srsRAN 5G SA with Open5GS core, ZMQ RF simulation
-Force Tags      Emulated
+Test Tags       Emulated  srsran  open5gs
 Resource        ../../../../../tests/common.resource
-
-Suite Setup     Setup Suite
-Suite Teardown  Teardown Suite
+Suite Setup     Setup Stack
+Suite Teardown  Teardown Stack
 
 
 *** Variables ***
-${STACK}  srsran-open5gs-5g-emu
+${STACK}          srsran-open5gs-5g-emu
+${UE_TYPE}        srsran
+${CORE_TYPE}      open5gs
+@{CONTAINERS}     upf  smf  amf  nrf  udr  udm  ausf  pcf  bsf  nssf  scp  gnb  ue
+@{FILES_TO_SAVE}  gnb:/mnt/srsran/gnb.yaml
 
 
 *** Test Cases ***
 Verify Successful Startup
-    Containers Should Running  upf  smf  amf  nrf  udr  udm  ausf  pcf  bsf  nssf  scp  gnb  ue  mongo
+    Containers Should Be Running  @{CONTAINERS}
     No Running Container Should Be  unhealthy
     No Running Container Should Be  starting
     No Container Should Be Failed
 
 Verify UE Is Registered At AMF
-    ${MCC}=  Get Env  MCC
-    ${MNC}=  Get Env  MNC
-    ${UE_SOFT_MSIN}=  Get Env  UE_SOFT_MSIN
-    Container Log Should Match Regexp  amf  \\[imsi-${MCC}${MNC}${UE_SOFT_MSIN}\\] Registration complete
+    UE Should Be Registered At AMF
 
 Verify UE Connectivity
-    srsRAN UE Should Can Ping  8.8.8.8
+    UE Should Reach The Internet
 
 Verify PDU Session Establishment At SMF
-    Open5GS SMF Log Should Contain PDU Session Setup
-
-Collect Test Data
-    Collect Container Logs
-    Collect Container Versions
-    Collect Configuration Files
-
-
-*** Keywords ***
-Setup Suite
-    Log To Console  Setup Suite: run 'make run-${STACK}'
-    Start Process   make  run-${STACK}
-    Sleep  5s
-    Process Should Be Running
-    Wait Until Startup Complete  Open5GS SMF Log Should Contain PDU Session Setup
-
-Teardown Suite
-    Log To Console  Teardown Suite: run 'make stop-${STACK}'
-    Run Process   make  stop-${STACK}
-    No Container Should Running  upf  smf  amf  nrf  udr  udm  ausf  pcf  bsf  nssf  scp  gnb  ue  mongo
-    Terminate All Processes  kill=True
-
-Collect Container Logs
-    Save Container Logs  upf  smf  amf  nrf  udr  udm  ausf  pcf  bsf  nssf  scp  gnb  ue  mongo
-
-Collect Container Versions
-    Set Container Versions Metadata  upf  smf  amf  nrf  udr  udm  ausf  pcf  bsf  nssf  scp  gnb  ue
-
-Collect Configuration Files
-    Save Local Files  gnb.yaml
+    SMF Log Should Contain PDU Session Setup

--- a/modules/o5gc/stacks/ueransim-oai/tests/rlsim.robot
+++ b/modules/o5gc/stacks/ueransim-oai/tests/rlsim.robot
@@ -1,60 +1,31 @@
 *** Settings ***
 Documentation   UERANSIM 5G SA with OAI core, radio link simulation
-Force Tags      Emulated
+Test Tags       Emulated  ueransim  oai-cn
 Resource        ../../../../../tests/common.resource
-
-Suite Setup     Setup Suite
-Suite Teardown  Teardown Suite
+Suite Setup     Setup Stack
+Suite Teardown  Teardown Stack
 
 
 *** Variables ***
-${STACK}  ueransim-oai
+${STACK}          ueransim-oai
+${UE_TYPE}        ueransim
+${CORE_TYPE}      oai
+@{CONTAINERS}     upf  smf  amf  nrf  udr  udm  ausf  gnb  ue  mysql
+@{FILES_TO_SAVE}  gnb:/o5gc/ueransim/config/gnb.yaml  ue:/o5gc/ueransim/config/ue.yaml
 
 
 *** Test Cases ***
 Verify Successful Startup
-    Containers Should Running  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue  mysql
+    Containers Should Be Running  @{CONTAINERS}
     No Running Container Should Be  unhealthy
     No Running Container Should Be  starting
     No Container Should Be Failed
 
 Verify UE Is Registered At AMF
-    ${MCC}=  Get Env  MCC
-    ${MNC}=  Get Env  MNC
-    ${UE_SOFT_MSIN}=  Get Env  UE_SOFT_MSIN
-    Container Log Should Match Regexp  amf  5GMM-REGISTERED\\s+\\|\\s+${MCC}${MNC}${UE_SOFT_MSIN}
+    UE Should Be Registered At AMF
 
 Verify UE Connectivity
-    UERANSIM UE Should Can Ping  8.8.8.8
+    UE Should Reach The Internet
 
 Verify PDU Session Establishment At SMF
-    OAI SMF Log Should Contain PDU Session Setup
-
-Collect Test Data
-    Collect Container Logs
-    Collect Container Versions
-    Collect Configuration Files
-
-
-*** Keywords ***
-Setup Suite
-    Log To Console  Setup Suite: run 'make run-${STACK}'
-    Start Process   make  run-${STACK}
-    Sleep  5s
-    Process Should Be Running
-    Wait Until Startup Complete  OAI SMF Log Should Contain PDU Session Setup
-
-Teardown Suite
-    Log To Console  Teardown Suite: run 'make stop-${STACK}'
-    Run Process   make  stop-${STACK}
-    No Container Should Running  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue  mysql
-    Terminate All Processes  kill=True
-
-Collect Container Logs
-    Save Container Logs  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue
-
-Collect Container Versions
-    Set Container Versions Metadata  upf  smf  amf  nrf  udr  udm  ausf  gnb  ue
-
-Collect Configuration Files
-    Save Files From Container  gnb:/o5gc/ueransim/config/gnb.yaml  ue:/o5gc/ueransim/config/ue.yaml
+    SMF Log Should Contain PDU Session Setup

--- a/modules/o5gc/stacks/ueransim-open5gs/tests/rlsim.robot
+++ b/modules/o5gc/stacks/ueransim-open5gs/tests/rlsim.robot
@@ -1,60 +1,31 @@
 *** Settings ***
 Documentation   UERANSIM 5G SA with Open5GS core, radio link simulation
-Force Tags      Emulated
+Test Tags       Emulated  ueransim  open5gs
 Resource        ../../../../../tests/common.resource
-
-Suite Setup     Setup Suite
-Suite Teardown  Teardown Suite
+Suite Setup     Setup Stack
+Suite Teardown  Teardown Stack
 
 
 *** Variables ***
-${STACK}  ueransim-open5gs
+${STACK}          ueransim-open5gs
+${UE_TYPE}        ueransim
+${CORE_TYPE}      open5gs
+@{CONTAINERS}     upf  smf  amf  nrf  ausf  udr  udm  pcf  bsf  nssf  scp  gnb  ue
+@{FILES_TO_SAVE}  gnb:/o5gc/ueransim/config/gnb.yaml  ue:/o5gc/ueransim/config/ue.yaml
 
 
 *** Test Cases ***
 Verify Successful Startup
-    Containers Should Running  upf  smf  amf  nrf  ausf  udr  udm  pcf  bsf  nssf  scp  gnb  ue  mongo
+    Containers Should Be Running  @{CONTAINERS}
     No Running Container Should Be  unhealthy
     No Running Container Should Be  starting
     No Container Should Be Failed
 
 Verify UE Is Registered At AMF
-    ${MCC}=  Get Env  MCC
-    ${MNC}=  Get Env  MNC
-    ${UE_SOFT_MSIN}=  Get Env  UE_SOFT_MSIN
-    Container Log Should Match Regexp  amf  \\[imsi-${MCC}${MNC}${UE_SOFT_MSIN}\\] Registration complete
+    UE Should Be Registered At AMF
 
 Verify UE Connectivity
-    UERANSIM UE Should Can Ping  8.8.8.8
+    UE Should Reach The Internet
 
 Verify PDU Session Establishment At SMF
-    Open5GS SMF Log Should Contain PDU Session Setup
-
-Collect Test Data
-    Collect Container Logs
-    Collect Container Versions
-    Collect Configuration Files
-
-
-*** Keywords ***
-Setup Suite
-    Log To Console  Setup Suite: run 'make run-${STACK}'
-    Start Process   make  run-${STACK}
-    Sleep  5s
-    Process Should Be Running
-    Wait Until Startup Complete  Open5GS SMF Log Should Contain PDU Session Setup
-
-Teardown Suite
-    Log To Console  Teardown Suite: run 'make stop-${STACK}'
-    Run Process   make  stop-${STACK}
-    No Container Should Running  upf  smf  amf  nrf  ausf  udr  udm  pcf  bsf  nssf  scp  gnb  ue  mongo
-    Terminate All Processes  kill=True
-
-Collect Container Logs
-    Save Container Logs  upf  smf  amf  nrf  ausf  udr  udm  pcf  bsf  nssf  scp  gnb  ue  mongo
-
-Collect Container Versions
-    Set Container Versions Metadata  upf  smf  amf  nrf  ausf  udr  udm  pcf  bsf  nssf  scp  gnb  ue
-
-Collect Configuration Files
-    Save Files From Container  gnb:/o5gc/ueransim/config/gnb.yaml  ue:/o5gc/ueransim/config/ue.yaml
+    SMF Log Should Contain PDU Session Setup

--- a/tests/common.resource
+++ b/tests/common.resource
@@ -6,56 +6,80 @@ Library  String
 Library  get_env.py
 
 
-*** Keywords ***
-Wait
-    [Arguments]  ${time}  ${msg}=${EMPTY}
-    Log To Console  Waiting ${time} ${msg}
-    Sleep  ${time}
+*** Variables ***
+# Tunnel interface each UE implementation brings up. These names are fixed by the
+# UE software rather than configurable: see docker/oai/ran-entrypoint.sh and
+# docker/srsran/4g/entrypoint.sh; UERANSIM creates uesimtun0 itself.
+&{UE_TUN_IFACE}  oai=oaitun_ue1  ueransim=uesimtun0  srsran=tun_srsue
 
+# Core-specific assertions. The AMF and SMF log formats differ between OAI and
+# Open5GS, so each core gets its own keyword and CORE_TYPE picks the pair.
+&{CORE_PDU_SESSION_KW}   oai=OAI SMF Log Should Contain PDU Session Setup
+...                      open5gs=Open5GS SMF Log Should Contain PDU Session Setup
+&{CORE_REGISTRATION_KW}  oai=OAI AMF Log Should Show UE Registered
+...                      open5gs=Open5GS AMF Log Should Show UE Registered
+
+
+*** Keywords ***
 Wait Until Startup Complete
-    [Documentation]  Poll until the stack is ready instead of sleeping a fixed time.
-    ...              ${pdu_session_keyword} is the stack-specific keyword that asserts
-    ...              the SMF has established a PDU session (the last startup milestone);
-    ...              its log format differs per core (OAI vs Open5GS). ${timeout} is the
-    ...              ceiling; the keyword returns as soon as the core network, gNB and UE
-    ...              have completed startup.
-    [Arguments]  ${pdu_session_keyword}  ${timeout}=120s  ${interval}=3s
+    [Documentation]  Poll until the stack is ready. The last startup milestone is the SMF
+    ...    establishing a PDU session, asserted by the keyword CORE_TYPE selects.
+    ...    ${timeout} is the ceiling; the keyword returns as soon as the core network,
+    ...    gNB and UE have completed startup.
+    [Arguments]  ${timeout}=120s  ${interval}=3s
     Log To Console  Waiting up to ${timeout} for core network, gNB and UE startup
-    Wait Until Keyword Succeeds  ${timeout}  ${interval}
-    ...          Startup Should Be Complete  ${pdu_session_keyword}
+    Wait Until Keyword Succeeds  ${timeout}  ${interval}  Startup Should Be Complete
 
 Startup Should Be Complete
-    [Arguments]  ${pdu_session_keyword}
     No Running Container Should Be  starting
     No Running Container Should Be  unhealthy
-    Run Keyword  ${pdu_session_keyword}
+    SMF Log Should Contain PDU Session Setup
 
-Get Suite Paths
-    ${etc}  ${suite id}  ${_}  ${_} =  Split String From Right  ${SUITE SOURCE}  /  3
-    Create Directory  ${OUTPUT_DIR}/${suite id}
-    RETURN  ${etc}/${suite id}  ${OUTPUT_DIR}/${suite id}
+Setup Stack
+    [Documentation]  Start the stack (make run-${STACK}) and wait until it is ready.
+    ...    Used as Suite Setup; the suite only supplies ${STACK}.
+    Log To Console  Setup Stack: run 'make run-${STACK}'
+    Start Process  make  run-${STACK}
+    # Give 'make' a moment to fork the compose stack before we assert the process
+    # is alive; actual readiness is polled by Wait Until Startup Complete below.
+    Sleep  5s
+    Process Should Be Running
+    Wait Until Startup Complete
+
+Teardown Stack
+    [Documentation]  Collect artifacts (best effort) then stop the stack. Runs on
+    ...    every exit, including a failed Suite Setup, so logs survive a bad startup.
+    Run Keyword And Warn On Failure  Collect Test Data
+    Log To Console  Teardown Stack: run 'make stop-${STACK}'
+    Run Process  make  stop-${STACK}
+    No Container Should Be Running  @{CONTAINERS}
+    Terminate All Processes  kill=True
+
+Collect Test Data
+    Save Container Logs  @{CONTAINERS}
+    Set Container Versions Metadata  @{CONTAINERS}
+    Save Files From Container  @{FILES_TO_SAVE}
+
+Get Suite Output Dir
+    [Documentation]  Per-suite results directory, created on first use.
+    ${_}  ${suite_id}  ${_}  ${_} =  Split String From Right  ${SUITE SOURCE}  /  3
+    Create Directory  ${OUTPUT_DIR}/${suite_id}
+    RETURN  ${OUTPUT_DIR}/${suite_id}
 
 Save Files From Container
     [Arguments]  @{files}
-    ${_}  ${suite output dir} =  Get Suite Paths
+    ${suite_output_dir} =  Get Suite Output Dir
     FOR  ${file}  IN  @{files}
-        ${result} =  Run Process  docker  cp  ${file}  ${suite output dir}/
+        ${result} =  Run Process  docker  cp  ${file}  ${suite_output_dir}/
         Should Be Equal  ${result.rc}  ${0}
-    END
-
-Save Local Files
-    [Arguments]  @{files}
-    ${local dir}  ${suite output dir} =  Get Suite Paths
-    FOR  ${file}  IN  @{files}
-        Copy File  ${local dir}/${file}  ${suite output dir}/
     END
 
 Save Container Logs
     [Arguments]  @{containers}
-    ${_}  ${suite output dir} =  Get Suite Paths
+    ${suite_output_dir} =  Get Suite Output Dir
     FOR  ${container}  IN  @{containers}
         ${result} =  Run Process  docker  logs  ${container}
-        ...          stdout=${suite output dir}/${container}.log  stderr=STDOUT
+        ...          stdout=${suite_output_dir}/${container}.log  stderr=STDOUT
         Should Be Equal  ${result.rc}  ${0}
     END
 
@@ -67,11 +91,16 @@ No Running Container Should Be
     Should Be Empty  ${result.stdout}
 
 No Container Should Be Failed
-    ${result} =  Run Process  docker  ps  --all  --format  {{.Names}}: {{.Status}}
-    ...          --filter  status\=exited  |  grep  -v  Exited (0)  shell=True  stderr=STDOUT
-    Should Be Empty  ${result.stdout}
+    [Documentation]  Fail if any container exited with a non-zero status. Cleanly
+    ...    exited containers (Exited (0)) are allowed. The exit code is the first
+    ...    character after "Exited (": 0 is success, anything else is a failure.
+    ${result} =  Run Process  docker  ps  --all  --filter  status\=exited
+    ...          --format  {{.Names}}: {{.Status}}  stderr=STDOUT
+    Should Be Equal  ${result.rc}  ${0}
+    ${failed} =  Get Lines Matching Regexp  ${result.stdout}  Exited \\([^0]  partial_match=True
+    Should Be Empty  ${failed}  Containers exited with a non-zero status:\n${failed}
 
-No Container Should Running
+No Container Should Be Running
     [Arguments]  @{containers}
     FOR  ${container}  IN  @{containers}
         ${result} =  Run Process  docker  ps  -q  --filter  status\=running  --filter  name\=${container}
@@ -79,7 +108,7 @@ No Container Should Running
         Should Be Empty  ${result.stdout}
     END
 
-Containers Should Running
+Containers Should Be Running
     [Arguments]  @{containers}
     FOR  ${container}  IN  @{containers}
         ${result} =  Run Process  docker  ps  -q  --filter  status\=running  --filter  name\=${container}
@@ -96,42 +125,60 @@ Container Log Should Match Regexp
     Remove File  ${TEMPDIR}/o5gc.test.${container}.log
 
 Set Container Versions Metadata
+    [Documentation]  Record each container's /etc/image_version as suite metadata.
+    ...    Containers without that file (e.g. the mysql/mongo database image) are
+    ...    skipped with a warning rather than failing the whole collection, so the
+    ...    caller can pass the full container list.
     [Arguments]  @{containers}
     FOR  ${container}  IN  @{containers}
         ${result} =  Run Process  docker  exec  ${container}  cat  /etc/image_version
-        Should Be Equal  ${result.rc}  ${0}
+        IF  ${result.rc}
+            Log  Skipping ${container}: no /etc/image_version  level=WARN
+            CONTINUE
+        END
         Set Suite Metadata  Docker Container Versions  - ${container}: ${result.stdout}\n  append=True
     END
 
-OAI UE Should Can Ping
-    [Arguments]  ${addr}
-    ${result} =  Run Process  docker  exec  ue  ping  -I  oaitun_ue1  -c  1  ${addr}
+UE Should Reach The Internet
+    [Documentation]  Ping 8.8.8.8 from the UE through its tunnel interface.
+    ...    ${ue} names the UE implementation (oai, ueransim, srsran) and defaults to the
+    ...    suite's UE_TYPE; the interface it brings up is looked up in UE_TUN_IFACE.
+    [Arguments]  ${ue}=${UE_TYPE}
+    ${result} =  Run Process  docker  exec  ue  ping  -I  ${UE_TUN_IFACE}[${ue}]  -c  1  8.8.8.8
     Should Be Empty  ${result.stderr}
     Should Be Equal  ${result.rc}  ${0}
     Log  ${result.stdout}
 
+UE Should Be Registered At AMF
+    [Documentation]  Assert the AMF registered the UE whose IMSI is built from the
+    ...    stack's MCC/MNC/MSIN. ${core} names the core network and defaults to the suite's CORE_TYPE.
+    [Arguments]  ${core}=${CORE_TYPE}
+    ${mcc} =  Get Env  MCC
+    ${mnc} =  Get Env  MNC
+    ${msin} =  Get Env  UE_SOFT_MSIN
+    Run Keyword  ${CORE_REGISTRATION_KW}[${core}]  ${mcc}${mnc}${msin}
+
+SMF Log Should Contain PDU Session Setup
+    [Documentation]  Assert the SMF established a PDU session. ${core} names the
+    ...              core network (oai, open5gs) and defaults to CORE_TYPE.
+    [Arguments]  ${core}=${CORE_TYPE}
+    Run Keyword  ${CORE_PDU_SESSION_KW}[${core}]
+
+OAI AMF Log Should Show UE Registered
+    [Arguments]  ${imsi}
+    Container Log Should Match Regexp  amf  5GMM-REGISTERED\\s+\\|\\s+${imsi}
+
+Open5GS AMF Log Should Show UE Registered
+    [Arguments]  ${imsi}
+    Container Log Should Match Regexp  amf  \\[imsi-${imsi}\\] Registration complete
+
 OAI SMF Log Should Contain PDU Session Setup
-    # see SMF verifySanityCheckDeployment.py
     Container Log Should Match Regexp  smf  Received a SM context create request from AMF
     Container Log Should Match Regexp  smf  PDU Session Create SM Context Request
     Container Log Should Match Regexp  smf  PDU_SESSION_ESTABLISHMENT_ACCEPT, encode starting
     Container Log Should Match Regexp  smf  Set PDU Session Status to PDU Session Status Establishment Pending
     Container Log Should Match Regexp  smf  PDU_SESSION_ESTABLISHMENT_UE_REQUESTED
     Container Log Should Match Regexp  smf  Set PDU Session Status to PDU Session Status Active
-
-UERANSIM UE Should Can Ping
-    [Arguments]  ${addr}
-    ${result} =  Run Process  docker  exec  ue  ping  -I  uesimtun0  -c  1  ${addr}
-    Should Be Empty  ${result.stderr}
-    Should Be Equal  ${result.rc}  ${0}
-    Log  ${result.stdout}
-
-srsRAN UE Should Can Ping
-    [Arguments]  ${addr}
-    ${result} =  Run Process  docker  exec  ue  ping  -I  tun_srsue  -c  1  ${addr}
-    Should Be Empty  ${result.stderr}
-    Should Be Equal  ${result.rc}  ${0}
-    Log  ${result.stdout}
 
 Open5GS SMF Log Should Contain PDU Session Setup
     Container Log Should Match Regexp  smf  \\[Added\\] Number of SMF-Sessions is now

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
-robotframework>=5,<6
+robotframework>=6,<7
 robotframework-robocop>=6,<7
 python-dotenv
+click
+typing_extensions

--- a/tests/robocop.toml
+++ b/tests/robocop.toml
@@ -3,4 +3,8 @@ ignore = [
     "missing-doc-keyword",
     "missing-doc-test-case",
     "wrong-case-in-keyword-name",
+    # Suites declare variables (UE_TYPE, STACK, ...) that only common.resource
+    # consumes, as keyword defaults. Robocop analyses each file on its own, so it
+    # cannot see those uses and reports every such variable as unused.
+    "unused-variable",
 ]

--- a/tests/targets.mk
+++ b/tests/targets.mk
@@ -12,9 +12,14 @@ tests/.venv.build: tests/requirements.txt
 	$(ACTIVATE_TEST_VENV); pip install -r $<
 	@touch $@
 
-tests-run-all-emulated: tests-install-venv
-	${ROBOT} -N "open5Gcube" -i Emulated                                      \
-	    -d tests/results/all-emulated/$$(date '+%Y%m%d-%H%M') modules
+# One `tests-run-all-<tag>` target per tag used by any suite, e.g.
+# `make tests-run-all-open5gs` or `make tests-run-all-oai-cn`. The tag list is
+# derived from the suites' `Test Tags` lines.
+TEST_TAGS := $(sort $(shell sed -n 's/^Test Tags//p'                          \
+    modules/*/stacks/*/tests/*.robot | tr 'A-Z' 'a-z'))
+$(addprefix tests-run-all-,${TEST_TAGS}): tests-run-all-%: tests-install-venv
+	${ROBOT} -N "open5Gcube" -i $*                                            \
+	    -d tests/results/all-$*/$$(date '+%Y%m%d-%H%M') modules
 
 # Explicit tests-run-<stack> targets for every stack that has a tests/ directory
 # e.g. `make tests-run-ueransim-open5gs`.
@@ -24,7 +29,8 @@ $(addprefix tests-run-,${TEST_STACKS}): tests-run-%: tests-install-venv
 	    $(wildcard modules/*/stacks/$*/tests)
 
 tests-lint: tests-install-venv
-	$(ACTIVATE_TEST_VENV); robocop check --config tests/robocop.toml modules tests
+	$(ACTIVATE_TEST_VENV); robocop check --config tests/robocop.toml           \
+	    modules/*/stacks tests
 
 tests-clean:
 	rm -rf tests/results


### PR DESCRIPTION
Upgrade to Robot Framework 6, deduplicate the stack suites into a shared common.resource driven by ${UE_TYPE}/${CORE_TYPE}/@{CONTAINERS} variables, add per-component tags with tests-run-all-<tag> targets, collect config from the container, and fix No Container Should Be Failed (its shell pipe never detected a failure).